### PR TITLE
Avoid partial argument match

### DIFF
--- a/rchitect/completion.py
+++ b/rchitect/completion.py
@@ -20,7 +20,7 @@ tryCatch(
     }},
     error = function(e) {{
         if ({settimelimit}) base::setTimeLimit()
-        assign("comps", NULL, env = utils:::.CompletionEnv)
+        assign("comps", NULL, envir = utils:::.CompletionEnv)
     }}
 )
 """


### PR DESCRIPTION
It's best practice to use the full names of all arguments when
programming in order to avoid any partial matches.

Fixes #12.