### PR TITLE
Include license file with package.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE


### PR DESCRIPTION
conda-forge requires recipes to include the license file. This is easier when the license file is distributed with the package. 

https://conda-forge.org/docs/maintainer/adding_pkgs.html#packaging-the-license-manually

This is also best practice, since the MIT license states that the file must be included whenever the code is:

> The above copyright notice and this permission notice shall be included in
all copies or substantial portions of the Software.

The file I've added in this PR essentially ensure that the file `LICENSE` is included when the Python package is built.