### PR TITLE
Avoid loading hidden R 4.6 C API symbols

### DIFF
--- a/rchitect/_cffi/R.h
+++ b/rchitect/_cffi/R.h
@@ -141,16 +141,16 @@ RAPI_EXTERN Rboolean (*Rf_isString)(SEXP s);
 RAPI_EXTERN Rboolean (*Rf_isObject)(SEXP s);
 
 RAPI_EXTERN int (*TYPEOF)(SEXP x);
-RAPI_EXTERN int (*IS_S4_OBJECT)(SEXP x);
+// RAPI_EXTERN int (*IS_S4_OBJECT)(SEXP x);
 
 RAPI_EXTERN int (*LENGTH)(SEXP x);
 RAPI_EXTERN R_xlen_t (*XLENGTH)(SEXP x);
-RAPI_EXTERN R_xlen_t (*TRUELENGTH)(SEXP x);
-RAPI_EXTERN void (*SETLENGTH)(SEXP x, R_xlen_t v);
-RAPI_EXTERN void (*SET_TRUELENGTH)(SEXP x, R_xlen_t v);
+// RAPI_EXTERN R_xlen_t (*TRUELENGTH)(SEXP x);
+// RAPI_EXTERN void (*SETLENGTH)(SEXP x, R_xlen_t v);
+// RAPI_EXTERN void (*SET_TRUELENGTH)(SEXP x, R_xlen_t v);
 RAPI_EXTERN int (*IS_LONG_VEC)(SEXP x);
-RAPI_EXTERN int (*LEVELS)(SEXP x);
-RAPI_EXTERN int (*SETLEVELS)(SEXP x, int v);
+// RAPI_EXTERN int (*LEVELS)(SEXP x);
+// RAPI_EXTERN int (*SETLEVELS)(SEXP x, int v);
 
 // Vector Access Functions
 RAPI_EXTERN int *(*LOGICAL)(SEXP x);
@@ -288,7 +288,7 @@ RAPI_EXTERN SEXP (*Rf_duplicate)(SEXP);
 RAPI_EXTERN SEXP (*Rf_shallow_duplicate)(SEXP);
 // RAPI_EXTERN SEXP (*R_duplicate_attr)(SEXP);
 // RAPI_EXTERN SEXP (*R_shallow_duplicate_attr)(SEXP);
-RAPI_EXTERN SEXP (*Rf_lazy_duplicate)(SEXP);
+// RAPI_EXTERN SEXP (*Rf_lazy_duplicate)(SEXP);
 
 RAPI_EXTERN SEXP (*Rf_duplicated)(SEXP, Rboolean);
 RAPI_EXTERN Rboolean (*R_envHasNoSpecialSymbols)(SEXP);
@@ -321,7 +321,7 @@ RAPI_EXTERN SEXP (*Rf_matchE)(SEXP, SEXP, int, SEXP);
 RAPI_EXTERN SEXP (*Rf_namesgets)(SEXP, SEXP);
 RAPI_EXTERN SEXP (*Rf_mkChar)(const char *);
 RAPI_EXTERN SEXP (*Rf_mkCharLen)(const char *, int);
-RAPI_EXTERN Rboolean (*Rf_NonNullStringMatch)(SEXP, SEXP);
+// RAPI_EXTERN Rboolean (*Rf_NonNullStringMatch)(SEXP, SEXP);
 RAPI_EXTERN int (*Rf_ncols)(SEXP);
 RAPI_EXTERN int (*Rf_nrows)(SEXP);
 RAPI_EXTERN SEXP (*Rf_nthcdr)(SEXP, int);
@@ -450,8 +450,8 @@ RAPI_EXTERN Rboolean (*Rf_isPairList)(SEXP);
 RAPI_EXTERN Rboolean (*Rf_isPrimitive)(SEXP);
 RAPI_EXTERN Rboolean (*Rf_isTs)(SEXP);
 RAPI_EXTERN Rboolean (*Rf_isUserBinop)(SEXP);
-RAPI_EXTERN Rboolean (*Rf_isValidString)(SEXP);
-RAPI_EXTERN Rboolean (*Rf_isValidStringF)(SEXP);
+// RAPI_EXTERN Rboolean (*Rf_isValidString)(SEXP);
+// RAPI_EXTERN Rboolean (*Rf_isValidStringF)(SEXP);
 RAPI_EXTERN Rboolean (*Rf_isVector)(SEXP);
 RAPI_EXTERN Rboolean (*Rf_isVectorAtomic)(SEXP);
 RAPI_EXTERN Rboolean (*Rf_isVectorList)(SEXP);
@@ -482,7 +482,7 @@ RAPI_EXTERN SEXP (*Rf_ScalarRaw)(Rbyte);
 RAPI_EXTERN SEXP (*Rf_ScalarReal)(double);
 RAPI_EXTERN SEXP (*Rf_ScalarString)(SEXP);
 RAPI_EXTERN R_xlen_t (*Rf_xlength)(SEXP);
-RAPI_EXTERN R_xlen_t (*XTRUELENGTH)(SEXP x);
+// RAPI_EXTERN R_xlen_t (*XTRUELENGTH)(SEXP x);
 // RAPI_EXTERN int (*LENGTH_EX)(SEXP x, const char *file, int line);
 // RAPI_EXTERN R_xlen_t (*XLENGTH_EX)(SEXP x);
 

--- a/rchitect/_cffi/libR.c
+++ b/rchitect/_cffi/libR.c
@@ -164,16 +164,16 @@ int _libR_load_symbols() {
     LOAD_SYMBOL(Rf_isObject);
 
     LOAD_SYMBOL(TYPEOF);
-    LOAD_SYMBOL(IS_S4_OBJECT);
+    // LOAD_SYMBOL(IS_S4_OBJECT);
 
     LOAD_SYMBOL(LENGTH);
     LOAD_SYMBOL(XLENGTH);
-    LOAD_SYMBOL(TRUELENGTH);
-    LOAD_SYMBOL(SETLENGTH);
-    LOAD_SYMBOL(SET_TRUELENGTH);
+    // LOAD_SYMBOL(TRUELENGTH);
+    // LOAD_SYMBOL(SETLENGTH);
+    // LOAD_SYMBOL(SET_TRUELENGTH);
     LOAD_SYMBOL(IS_LONG_VEC);
-    LOAD_SYMBOL(LEVELS);
-    LOAD_SYMBOL(SETLEVELS);
+    // LOAD_SYMBOL(LEVELS);
+    // LOAD_SYMBOL(SETLEVELS);
 
     LOAD_SYMBOL(LOGICAL);
     LOAD_SYMBOL(INTEGER);
@@ -258,7 +258,7 @@ int _libR_load_symbols() {
     LOAD_SYMBOL(Rf_shallow_duplicate);
     // LOAD_SYMBOL(R_duplicate_attr);
     // LOAD_SYMBOL(R_shallow_duplicate_attr);
-    LOAD_SYMBOL(Rf_lazy_duplicate);
+    // LOAD_SYMBOL(Rf_lazy_duplicate);
 
     LOAD_SYMBOL(Rf_duplicated);
     // LOAD_SYMBOL(R_envHasNoSpecialSymbols);
@@ -291,7 +291,7 @@ int _libR_load_symbols() {
     LOAD_SYMBOL(Rf_namesgets);
     LOAD_SYMBOL(Rf_mkChar);
     LOAD_SYMBOL(Rf_mkCharLen);
-    LOAD_SYMBOL(Rf_NonNullStringMatch);
+    // LOAD_SYMBOL(Rf_NonNullStringMatch);
     LOAD_SYMBOL(Rf_ncols);
     LOAD_SYMBOL(Rf_nrows);
     LOAD_SYMBOL(Rf_nthcdr);
@@ -415,8 +415,8 @@ int _libR_load_symbols() {
     LOAD_SYMBOL(Rf_isPrimitive);
     LOAD_SYMBOL(Rf_isTs);
     // LOAD_SYMBOL(Rf_isUserBinop);
-    LOAD_SYMBOL(Rf_isValidString);
-    LOAD_SYMBOL(Rf_isValidStringF);
+    // LOAD_SYMBOL(Rf_isValidString);
+    // LOAD_SYMBOL(Rf_isValidStringF);
     LOAD_SYMBOL(Rf_isVector);
     LOAD_SYMBOL(Rf_isVectorAtomic);
     LOAD_SYMBOL(Rf_isVectorList);
@@ -447,7 +447,7 @@ int _libR_load_symbols() {
     LOAD_SYMBOL(Rf_ScalarReal);
     LOAD_SYMBOL(Rf_ScalarString);
     LOAD_SYMBOL(Rf_xlength);
-    LOAD_SYMBOL(XTRUELENGTH);
+    // LOAD_SYMBOL(XTRUELENGTH);
     // LOAD_SYMBOL(LENGTH_EX);
     // LOAD_SYMBOL(XLENGTH_EX);
 


### PR DESCRIPTION
## Summary

This PR stops rchitect from loading R C API entry points that are hidden in R 4.6.

R 4.6 hides several internal entry points and no longer declares them in installed headers.

> These entry points are now marked as hidden and no longer have declarations in installed header files: ENVFLAGS, EXTPTR_PROT, FRAME, ENCLOS, EXTPTR_PTR, EXTPTR_TAG, HASHTAB, IS_S4_OBJECT, LEVELS, NAMED, OBJECT, R_shallow_duplicate_attr, Rf_isValidString, Rf_lazy_duplicate, Rf_NonNullStringMatch, SETLENGTH, SETLEVELS, SET_BODY, SET_CLOENV, SET_ENCLOS, SET_FORMALS, SET_ENVFLAGS, SET_FRAME, SET_GROWABLE_BIT, SET_HASHTAB, SET_NAMED, SET_S4_OBJECT, SET_TRUELENGTH, STDVEC_DATAPTR, TRUELENGTH, UNSET_S4_OBJECT, XTRUELENGTH.

Since rchitect loads many R symbols eagerly during initialization, trying to load these hidden symbols can fail startup for downstream tools such as radian.

## Changes

- Comment out cffi declarations for hidden / unavailable R C API entry points.
- Comment out the corresponding `LOAD_SYMBOL(...)` calls in `_libR_load_symbols()`.
- Also comment out `Rf_isValidStringF`, which appears to be hidden as well even though it was not listed in the original R release note excerpt.
